### PR TITLE
feat(hotkey): add `mod+enter` hotkey for quick apply settings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default [
   },
   {
     rules: {
+      '@typescript-eslint/no-unnecessary-type-assertion': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
       '@typescript-eslint/no-empty-object-type': 'off',
       '@typescript-eslint/naming-convention': 'warn',

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -46,6 +46,10 @@ function extractTextFromChildren(children: Children): string {
   return '';
 }
 
+function formatKbdDisplay(text: string): string {
+  return text.replace(/\benter\b/gi, '⏎').replace(/\bcomma\b/gi, ',');
+}
+
 function normalizeHotkeyString(str: string | undefined | null): string | null {
   if (!str) return null;
   let normalized = str.trim().toLowerCase();
@@ -173,6 +177,16 @@ function Kbd({
 }: KbdProps) {
   const [isPressed, setIsPressed] = useState(false);
   const kbdRef = useRef<HTMLElement>(null);
+
+  const extractedText = useMemo(
+    () => extractTextFromChildren(children),
+    [children]
+  );
+  const isEscDisplay = !!extractedText && extractedText.toLowerCase() === 'esc';
+  const displayText = useMemo(
+    () => formatKbdDisplay(extractedText),
+    [extractedText]
+  );
 
   const hotkey = useMemo(() => {
     if (!useHotkey) return null;
@@ -313,10 +327,14 @@ function Kbd({
       <kbd
         ref={kbdRef}
         data-slot="kbd"
-        className={cn(kbdVariants({ variant }), className)}
+        className={cn(
+          kbdVariants({ variant }),
+          isEscDisplay && 'size-8',
+          className
+        )}
         {...props}
       >
-        {children}
+        {displayText || children}
       </kbd>
     );
   }
@@ -328,6 +346,7 @@ function Kbd({
       className={cn(
         !isCompound && !isSpace && 'aspect-square',
         isSpace && 'w-24',
+        isEscDisplay && 'size-8',
         kbdVariants({ variant }),
         isPressed && 'shadow-none',
         className
@@ -341,7 +360,7 @@ function Kbd({
         )}
       >
         <span className="align-center block text-center text-xs">
-          {children}
+          {displayText || children}
         </span>
       </span>
     </kbd>

--- a/src/contexts/settings/provider.tsx
+++ b/src/contexts/settings/provider.tsx
@@ -160,6 +160,21 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
     [toggleSettings]
   );
 
+  const isConfirmDisabled = !formState.isDirty || !formState.isValid;
+
+  useHotkeys(
+    'mod+enter',
+    (e) => {
+      e.preventDefault();
+
+      if (!isConfirmDisabled) {
+        applySettings();
+      }
+    },
+    { enabled: isOpen, enableOnFormTags: true },
+    [isConfirmDisabled, applySettings, isOpen]
+  );
+
   const contextValue = useMemo(
     () => ({
       isOpen,

--- a/src/contexts/settings/provider.tsx
+++ b/src/contexts/settings/provider.tsx
@@ -160,19 +160,19 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
     [toggleSettings]
   );
 
-  const isConfirmDisabled = !formState.isDirty || !formState.isValid;
-
   useHotkeys(
     'mod+enter',
     (e) => {
       e.preventDefault();
 
-      if (!isConfirmDisabled) {
-        applySettings();
-      }
+      const isConfirmDisabled = !formState.isDirty || !formState.isValid;
+
+      if (isConfirmDisabled) return;
+
+      applySettings();
     },
     { enabled: isOpen, enableOnFormTags: true },
-    [isConfirmDisabled, applySettings, isOpen]
+    [applySettings, isOpen]
   );
 
   const contextValue = useMemo(

--- a/src/features/app/scoreboard/controls/player-label.tsx
+++ b/src/features/app/scoreboard/controls/player-label.tsx
@@ -10,7 +10,7 @@ export const PlayerLabel = ({ children, className }: PlayerLabelProps) => {
   return (
     <Label
       className={cn(
-        'truncate text-center text-3xl leading-tight font-semibold text-white uppercase max-xl:text-2xl',
+        'mx-0 inline-block w-full truncate text-center text-2xl leading-snug font-bold text-white uppercase max-xl:text-xl',
         className
       )}
     >

--- a/src/features/app/settings/tabs/advance-settings.tsx
+++ b/src/features/app/settings/tabs/advance-settings.tsx
@@ -80,7 +80,7 @@ export const AdvanceSettings = () => {
   );
 
   return (
-    <FieldSet className="font-esbuild w-full">
+    <FieldSet className="w-full">
       <FieldGroup className="settings-field-group relative items-center">
         <FieldLabel className="settings-group-label text-2xl!">
           TOURNAMENT SETTINGS

--- a/src/features/app/settings/tabs/data/helps.ts
+++ b/src/features/app/settings/tabs/data/helps.ts
@@ -1,0 +1,59 @@
+export type KeyEntry = {
+  label?: string;
+  kbd?: string | (() => string);
+  className?: string;
+  labelClassName?: string;
+  isSeparator?: boolean;
+};
+
+export const systemKeys: Array<KeyEntry> = [
+  {
+    label: 'Open settings dialog',
+    kbd: () =>
+      navigator.userAgent.toUpperCase().includes('MAC')
+        ? '⌘ + comma'
+        : 'Ctrl + comma',
+  },
+  {
+    label: 'Close settings dialog',
+    kbd: 'Esc',
+  },
+  {
+    label: 'Apply settings',
+    kbd: () =>
+      navigator.userAgent.toUpperCase().includes('MAC')
+        ? '⌘ + Enter'
+        : 'Ctrl + Enter',
+  },
+  {
+    label: 'Start/Stop Timer',
+    kbd: 'Space',
+  },
+  {
+    label: 'Undo player actions',
+    kbd: () =>
+      navigator.userAgent.toUpperCase().includes('MAC') ? '⌘ + Z' : 'Ctrl + Z',
+  },
+];
+
+export const redKeys: Array<KeyEntry> = [
+  { label: 'Foul (Penalty)', kbd: 'W' },
+  { isSeparator: true },
+  { label: 'Head Kick (Crit) - 5 pts', kbd: 'E' },
+  { label: 'Trunk Kick (Crit) - 4 pts', kbd: 'Q' },
+  { label: 'Head Kick - 3 pts', kbd: 'D' },
+  { label: 'Trunk Kick - 2 pts', kbd: 'A' },
+  { label: 'Punch - 1 pt', kbd: 'S' },
+];
+
+export const blueKeys: Array<KeyEntry> = [
+  { label: 'Foul (Penalty)', kbd: 'I' },
+  { isSeparator: true },
+  { label: 'Head Kick (Crit) - 5 pts', kbd: 'U' },
+  { label: 'Body Kick (Crit) - 4 pts', kbd: 'O' },
+  { label: 'Head Kick - 3 pts', kbd: 'J' },
+  { label: 'Body Kick - 2 pts', kbd: 'L' },
+  { label: 'Punch - 1 pt', kbd: 'K' },
+];
+
+export default { systemKeys, redKeys, blueKeys };

--- a/src/features/app/settings/tabs/helps.tsx
+++ b/src/features/app/settings/tabs/helps.tsx
@@ -1,3 +1,4 @@
+import { blueKeys, redKeys, systemKeys } from './data/helps';
 import {
   FieldGroup,
   FieldLabel,
@@ -33,42 +34,25 @@ const KeyRow = ({ label, kbd, className, labelClassName }: KeyRowProps) => (
 
 export const Helps = () => {
   return (
-    <FieldSet className="font-esbuild w-full gap-6">
+    <FieldSet className="w-full gap-6">
       {/* System Controls */}
       <FieldGroup className="bg-card gap-4 rounded-md border p-4">
         <FieldLabel className="flex w-full justify-center text-center text-2xl font-semibold">
           SYSTEM KEY MAPPINGS
         </FieldLabel>
         <div className="flex flex-col gap-4">
-          <KeyRow
-            label="Open settings dialog"
-            kbd={
-              navigator.userAgent.toUpperCase().includes('MAC')
-                ? '⌘ + ,'
-                : 'Ctrl + ,'
-            }
-            labelClassName="text-lg leading-none"
-          />
-          <KeyRow
-            label="Close settings dialog"
-            kbd="Esc"
-            className="size-8"
-            labelClassName="text-lg leading-none"
-          />
-          <KeyRow
-            label="Start/Stop Timer"
-            kbd="Space"
-            labelClassName="text-lg leading-none"
-          />
-          <KeyRow
-            label="Undo player actions"
-            kbd={
-              navigator.userAgent.toUpperCase().includes('MAC')
-                ? '⌘ + Z'
-                : 'Ctrl + Z'
-            }
-            labelClassName="text-lg leading-none"
-          />
+          {systemKeys.map((item, i) => {
+            const kbd = typeof item.kbd === 'function' ? item.kbd() : item.kbd;
+            return (
+              <KeyRow
+                key={item.label ?? `system-${i}`}
+                label={item.label ?? ''}
+                kbd={kbd ?? ''}
+                className={item.className}
+                labelClassName="text-lg leading-none"
+              />
+            );
+          })}
         </div>
       </FieldGroup>
 
@@ -81,13 +65,23 @@ export const Helps = () => {
             RED PLAYER
           </FieldLabel>
           <div className="flex flex-col gap-3">
-            <KeyRow label="Foul (Penalty)" kbd="W" />
-            <Separator />
-            <KeyRow label="Head Kick (Crit) - 5 pts" kbd="E" />
-            <KeyRow label="Trunk Kick (Crit) - 4 pts" kbd="Q" />
-            <KeyRow label="Head Kick - 3 pts" kbd="D" />
-            <KeyRow label="Trunk Kick - 2 pts" kbd="A" />
-            <KeyRow label="Punch - 1 pt" kbd="S" />
+            {redKeys.map((item, i) =>
+              item.isSeparator ? (
+                <Separator key={`red-sep-${i}`} />
+              ) : (
+                <KeyRow
+                  key={item.label ?? `red-${i}`}
+                  label={item.label ?? ''}
+                  kbd={
+                    typeof item.kbd === 'function'
+                      ? item.kbd()
+                      : (item.kbd ?? '')
+                  }
+                  className={item.className}
+                  labelClassName={item.labelClassName}
+                />
+              )
+            )}
           </div>
         </FieldGroup>
 
@@ -97,13 +91,23 @@ export const Helps = () => {
             BLUE PLAYER
           </FieldLabel>
           <div className="flex flex-col gap-3">
-            <KeyRow label="Foul (Penalty)" kbd="I" />
-            <Separator />
-            <KeyRow label="Head Kick (Crit) - 5 pts" kbd="U" />
-            <KeyRow label="Body Kick (Crit) - 4 pts" kbd="O" />
-            <KeyRow label="Head Kick - 3 pts" kbd="J" />
-            <KeyRow label="Body Kick - 2 pts" kbd="L" />
-            <KeyRow label="Punch - 1 pt" kbd="K" />
+            {blueKeys.map((item, i) =>
+              item.isSeparator ? (
+                <Separator key={`blue-sep-${i}`} />
+              ) : (
+                <KeyRow
+                  key={item.label ?? `blue-${i}`}
+                  label={item.label ?? ''}
+                  kbd={
+                    typeof item.kbd === 'function'
+                      ? item.kbd()
+                      : (item.kbd ?? '')
+                  }
+                  className={item.className}
+                  labelClassName={item.labelClassName}
+                />
+              )
+            )}
           </div>
         </FieldGroup>
       </div>

--- a/src/features/app/settings/tabs/standard-settings.tsx
+++ b/src/features/app/settings/tabs/standard-settings.tsx
@@ -73,7 +73,7 @@ export const StandardSettings = () => {
   };
 
   return (
-    <FieldSet className="font-esbuild w-full">
+    <FieldSet className="w-full">
       <FieldGroup className="settings-field-group">
         <FieldLabel className="settings-group-label">
           SELECT PLAYER AVATARS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (mod+enter) to confirm settings changes.
  * Enhanced keybindings documentation with platform-specific modifiers (⌘ for macOS, Ctrl for others).

* **Style**
  * Improved keyboard shortcut label display with symbol transformations.
  * Updated player label font sizing and layout.
  * Refined typography in settings interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->