### PR TITLE
fix(tournament): allow restoring ongoing matches

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,6 +59,17 @@ _Avoid_: Consolation bout
 The client-side selection flow for tournament, group, and match used before a bout starts.
 _Avoid_: Setup wizard
 
+**Arena score (server)**:
+Persisted **`redWins`** / **`blueWins`** on the **Match** row; authoritative after the operator confirms Advance Settings (**Apply**) for that match. Synced from the arena app via **`match.updateScore`** (including offline replay). A full page reload does **not** auto-restore the scoreboard from the server until Apply is used again (tournament match lists may not be ready immediately).
+_Avoid_: Treating only Zustand as source of truth for set wins after refresh
+
+**Arena combat snapshot (local)**:
+Best-effort **`localStorage`** under **`tku-arena-combat-snapshot:{matchId}`** (one blob per bout) for in-round **health**, **mana**, **fouls**, and **round/break timer fields** (`timeLeft`, break state) while Advance Settings has that match selected **and** the operator has applied it in the current session. Current schema is **v2** (v1 blobs still load for combat only; timer resets to a full round). A legacy single key **`tku-arena-combat-snapshot`** is read once per match for migration, then moved into the scoped key. Restored only when the snapshot’s **completed-round count** (`redWins + blueWins`) matches the server row; otherwise that match’s blob is removed as stale.
+_Avoid_: Relying on it for round winners or timer phase
+
+**Match format (BO3)**:
+Every **Match** is **best-of-three rounds** (first to **2** round wins). There is **no** configurable **`bestOf`** field on matches or tournaments.
+
 ## Relationships
 
 - A **Tournament** contains many **Groups**.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -138,7 +138,6 @@ model Match {
   round                    Int      @default(0)
   matchIndex               Int      @default(0)
   status                   String   @default("pending")
-  bestOf                   Int      @default(3)
   redAthleteId             String?  @db.ObjectId
   blueAthleteId            String?  @db.ObjectId
   redTournamentAthleteId   String?  @db.ObjectId

--- a/src/contexts/settings/context.ts
+++ b/src/contexts/settings/context.ts
@@ -70,8 +70,8 @@ type SettingsContextType = {
   setAdvanceFormState: (state: Partial<FormState>) => void;
 
   applySettings: () => void;
-  /** True while advance-tab confirm is running async work (claim, invalidation). */
   applySettingsPending: boolean;
+  arenaAdvanceApplyNum: number;
 };
 
 export const SettingsContext = createContext<SettingsContextType | undefined>(

--- a/src/contexts/settings/provider.tsx
+++ b/src/contexts/settings/provider.tsx
@@ -37,6 +37,7 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
     isValid: true,
   });
   const [applySettingsPending, setApplySettingsPending] = useState(false);
+  const [arenaAdvanceApplyNum, setarenaAdvanceApplyNum] = useState(0);
 
   const formState =
     activeTab === 'standard' ? standardFormState : advanceFormState;
@@ -213,6 +214,10 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
           resetMatch();
           resetAll();
 
+          if (advance.match) {
+            setarenaAdvanceApplyNum((n) => n + 1);
+          }
+
           toast.success('Settings applied', {
             description: 'Applied latest settings for the next matches.',
             className: 'min-w-8! mx-auto inset-x-0 justify-center',
@@ -286,6 +291,7 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
       setAdvanceFormState,
       applySettings,
       applySettingsPending,
+      arenaAdvanceApplyNum,
     }),
     [
       isOpen,
@@ -299,6 +305,7 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
       setAdvanceFormState,
       applySettings,
       applySettingsPending,
+      arenaAdvanceApplyNum,
     ]
   );
 

--- a/src/features/app/components/app-arena-side-effects.tsx
+++ b/src/features/app/components/app-arena-side-effects.tsx
@@ -1,12 +1,16 @@
 import { authClient } from '@/lib/auth-client';
 import { useSettings } from '@/contexts/settings';
+import { useArenaCombatSnapshotPersistence } from '@/features/app/hooks/use-arena-combat-snapshot-persistence';
 import { useArenaLastSelection } from '@/features/app/hooks/use-arena-last-selection';
+import { useArenaScoreboardHydration } from '@/features/app/hooks/use-arena-scoreboard-hydration';
 import { useMatchSync } from '@/features/app/hooks/use-match-sync';
 import { useReplayOnOnline } from '@/features/app/hooks/use-replay-on-online';
 import { useRoundSubmit } from '@/features/app/hooks/use-round-submit';
 
 export function AppArenaSideEffects() {
   useArenaLastSelection();
+  useArenaScoreboardHydration();
+  useArenaCombatSnapshotPersistence();
   useReplayOnOnline();
   useRoundSubmit();
 

--- a/src/features/app/components/scoreboard/index.tsx
+++ b/src/features/app/components/scoreboard/index.tsx
@@ -42,7 +42,7 @@ export const Scoreboard = ({ className }: ScoreboardProps) => {
       e.preventDefault();
       if (isOpen) return;
       useTimerStore.getState().reset();
-      usePlayerStore.getState().resetRoundCombatPreserveHealth();
+      usePlayerStore.getState().resetRoundStats();
     },
     { preventDefault: true },
     [isOpen]
@@ -57,6 +57,7 @@ export const Scoreboard = ({ className }: ScoreboardProps) => {
       useMatchStore.getState().resetMatch();
       useTimerStore.getState().reset();
       usePlayerStore.getState().resetMatchCombatPreservePlayers();
+      usePlayerStore.getState().resetHealth();
     },
     [isOpen]
   );

--- a/src/features/app/hooks/use-arena-combat-snapshot-persistence.ts
+++ b/src/features/app/hooks/use-arena-combat-snapshot-persistence.ts
@@ -1,0 +1,69 @@
+import * as React from 'react';
+
+import {
+  ARENA_COMBAT_SNAPSHOT_SCHEMA_VERSION,
+  isLikelyMongoObjectId,
+  saveArenaCombatSnapshot,
+} from '@/features/app/lib/arena-combat-snapshot';
+import { useSettings } from '@/contexts/settings';
+import { completedRoundsFromWins } from '@/lib/tournament/bo3';
+import { useMatchStore } from '@/stores/match-store';
+import { usePlayerStore } from '@/stores/player-store';
+import { useTimerStore } from '@/stores/timer-store';
+
+export function useArenaCombatSnapshotPersistence() {
+  const { formData, arenaAdvanceApplyNum } = useSettings();
+  const advanceMatch = formData.advance.match;
+  const advanceMatchRef = React.useRef(advanceMatch);
+  advanceMatchRef.current = advanceMatch;
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || arenaAdvanceApplyNum === 0) return;
+
+    let timer = 0;
+
+    const flush = () => {
+      const matchId = advanceMatchRef.current;
+      if (!matchId || !isLikelyMongoObjectId(matchId)) return;
+      const { red, blue } = usePlayerStore.getState();
+      const { redWon, blueWon } = useMatchStore.getState();
+      const t = useTimerStore.getState();
+      saveArenaCombatSnapshot(matchId, {
+        schemaVersion: ARENA_COMBAT_SNAPSHOT_SCHEMA_VERSION,
+        matchId,
+        completedRounds: completedRoundsFromWins(redWon, blueWon),
+        red: { health: red.health, mana: red.mana, fouls: red.fouls },
+        blue: { health: blue.health, mana: blue.mana, fouls: blue.fouls },
+        timer: {
+          timeLeftMs: t.timeLeft,
+          breakTimeLeftMs: t.breakTimeLeft,
+          isBreakTime: t.isBreakTime,
+          roundStarted: t.roundStarted,
+          roundEnded: t.roundEnded,
+          isRunning: t.isRunning,
+        },
+      });
+    };
+
+    const scheduleFlush = () => {
+      window.clearTimeout(timer);
+      timer = window.setTimeout(flush, 260);
+    };
+
+    const unsubPlayer = usePlayerStore.subscribe(scheduleFlush);
+    const unsubTimer = useTimerStore.subscribe(scheduleFlush);
+
+    const onPageHide = () => {
+      window.clearTimeout(timer);
+      flush();
+    };
+    window.addEventListener('pagehide', onPageHide);
+
+    return () => {
+      unsubPlayer();
+      unsubTimer();
+      window.removeEventListener('pagehide', onPageHide);
+      window.clearTimeout(timer);
+    };
+  }, [arenaAdvanceApplyNum]);
+}

--- a/src/features/app/hooks/use-arena-scoreboard-hydration.ts
+++ b/src/features/app/hooks/use-arena-scoreboard-hydration.ts
@@ -1,0 +1,100 @@
+import * as React from 'react';
+
+import { isServerMatchRowForSelectedBout } from '@/features/app/lib/arena-scoreboard-hydration-guard';
+import {
+  ARENA_COMBAT_SNAPSHOT_SCHEMA_VERSION,
+  applyPersistedArenaTimerState,
+  clearArenaCombatSnapshotForMatch,
+  isLikelyMongoObjectId,
+  readArenaCombatSnapshotForMatch,
+  snapshotMatchesCompletedRounds,
+} from '@/features/app/lib/arena-combat-snapshot';
+import { useSettings } from '@/contexts/settings';
+import { authClient } from '@/lib/auth-client';
+import { useMatchGet } from '@/queries/matches';
+import { useMatchStore } from '@/stores/match-store';
+import { usePlayerStore } from '@/stores/player-store';
+import { useTimerStore } from '@/stores/timer-store';
+
+export function useArenaScoreboardHydration() {
+  const { data: session } = authClient.useSession();
+  const { formData, arenaAdvanceApplyNum } = useSettings();
+  const matchId = formData.advance.match;
+  const roundDurationMs = Math.max(1, formData.advance.roundDuration) * 1000;
+
+  const hydrationEnabled =
+    Boolean(session?.user) &&
+    arenaAdvanceApplyNum > 0 &&
+    Boolean(matchId && isLikelyMongoObjectId(matchId));
+
+  const { data, isSuccess } = useMatchGet(matchId, hydrationEnabled);
+
+  const appliedKeyRef = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    appliedKeyRef.current = null;
+  }, [matchId, arenaAdvanceApplyNum]);
+
+  React.useEffect(() => {
+    if (
+      arenaAdvanceApplyNum === 0 ||
+      !isSuccess ||
+      !data ||
+      !matchId ||
+      !isLikelyMongoObjectId(matchId) ||
+      typeof window === 'undefined'
+    ) {
+      return;
+    }
+
+    const { redWins, blueWins } = data;
+    if (!isServerMatchRowForSelectedBout(matchId, data)) {
+      return;
+    }
+
+    const key = `${matchId}:${redWins}:${blueWins}`;
+    if (appliedKeyRef.current === key) return;
+    appliedKeyRef.current = key;
+
+    useMatchStore.getState().hydrateFromServerScores({ redWins, blueWins });
+
+    const snap = readArenaCombatSnapshotForMatch(matchId);
+    if (!snap) {
+      useTimerStore.getState().resetRoundStats(roundDurationMs);
+      return;
+    }
+
+    if (!snapshotMatchesCompletedRounds(snap, redWins, blueWins)) {
+      clearArenaCombatSnapshotForMatch(matchId);
+      useTimerStore.getState().resetRoundStats(roundDurationMs);
+      return;
+    }
+
+    if (snap.matchId !== matchId) {
+      clearArenaCombatSnapshotForMatch(matchId);
+      useTimerStore.getState().resetRoundStats(roundDurationMs);
+      return;
+    }
+
+    usePlayerStore.setState((s) => ({
+      red: {
+        ...s.red,
+        health: snap.red.health,
+        mana: snap.red.mana,
+        fouls: snap.red.fouls,
+      },
+      blue: {
+        ...s.blue,
+        health: snap.blue.health,
+        mana: snap.blue.mana,
+        fouls: snap.blue.fouls,
+      },
+    }));
+
+    if (snap.schemaVersion === ARENA_COMBAT_SNAPSHOT_SCHEMA_VERSION) {
+      applyPersistedArenaTimerState(snap.timer, roundDurationMs);
+    } else {
+      useTimerStore.getState().resetRoundStats(roundDurationMs);
+    }
+  }, [arenaAdvanceApplyNum, data, isSuccess, matchId, roundDurationMs]);
+}

--- a/src/features/app/hooks/use-finish-match.ts
+++ b/src/features/app/hooks/use-finish-match.ts
@@ -43,9 +43,46 @@ export function useFinishMatch() {
   }, [closeMatchResult, resetMatch, resetPlayers, resetTimer]);
 
   const accept = React.useCallback(() => {
-    resetArenaClientAfterResult();
+    closeMatchResult();
+    resetMatch();
+
+    const advance = formData.advance;
+    const ps = usePlayerStore.getState();
+    const ts = useTimerStore.getState();
+
+    if (advance.maxHealth > 0) {
+      ps.setMaxHealth(advance.maxHealth);
+    }
+    if (advance.roundDuration > 0) {
+      ts.setRoundDuration(advance.roundDuration * 1000);
+    }
+    if (advance.breakDuration > 0) {
+      ts.setBreakDuration(advance.breakDuration * 1000);
+    }
+    if (advance.redPlayerName) {
+      ps.setPlayerName('red', advance.redPlayerName);
+    }
+    if (advance.bluePlayerName) {
+      ps.setPlayerName('blue', advance.bluePlayerName);
+    }
+    if (advance.redPlayerAvatar) {
+      ps.setPlayerAvatar('red', advance.redPlayerAvatar);
+    }
+    if (advance.bluePlayerAvatar) {
+      ps.setPlayerAvatar('blue', advance.bluePlayerAvatar);
+    }
+
+    resetTimer();
+    resetPlayers();
     invalidateAdvanceSelection();
-  }, [invalidateAdvanceSelection, resetArenaClientAfterResult]);
+  }, [
+    closeMatchResult,
+    formData.advance,
+    invalidateAdvanceSelection,
+    resetMatch,
+    resetPlayers,
+    resetTimer,
+  ]);
 
   const cancel = React.useCallback(async () => {
     if (selectedMatchId && OBJECT_ID_RE.test(selectedMatchId)) {

--- a/src/features/app/hooks/use-round-submit.ts
+++ b/src/features/app/hooks/use-round-submit.ts
@@ -10,19 +10,41 @@ export function useRoundSubmit() {
   const { formData } = useSettings();
   const advanceMatch = formData.advance.match;
 
-  const { redWon, blueWon } = useMatchStore(
-    useShallow((s) => ({ redWon: s.redWon, blueWon: s.blueWon }))
+  const { redWon, blueWon, hydrationGeneration } = useMatchStore(
+    useShallow((s) => ({
+      redWon: s.redWon,
+      blueWon: s.blueWon,
+      hydrationGeneration: s.hydrationGeneration,
+    }))
   );
 
   const prevRed = React.useRef(redWon);
   const prevBlue = React.useRef(blueWon);
   const hydrated = React.useRef(false);
+  const prevAdvanceMatch = React.useRef<string | null>(advanceMatch);
+  const prevHydrationGen = React.useRef(hydrationGeneration);
 
   React.useEffect(() => {
     if (!advanceMatch) {
       prevRed.current = redWon;
       prevBlue.current = blueWon;
       hydrated.current = false;
+      prevAdvanceMatch.current = null;
+      return;
+    }
+
+    if (advanceMatch !== prevAdvanceMatch.current) {
+      prevAdvanceMatch.current = advanceMatch;
+      prevRed.current = redWon;
+      prevBlue.current = blueWon;
+      hydrated.current = false;
+    }
+
+    if (hydrationGeneration !== prevHydrationGen.current) {
+      prevHydrationGen.current = hydrationGeneration;
+      prevRed.current = redWon;
+      prevBlue.current = blueWon;
+      hydrated.current = true;
       return;
     }
 
@@ -49,5 +71,5 @@ export function useRoundSubmit() {
 
     prevRed.current = redWon;
     prevBlue.current = blueWon;
-  }, [advanceMatch, blueWon, mutateAsync, redWon]);
+  }, [advanceMatch, blueWon, hydrationGeneration, mutateAsync, redWon]);
 }

--- a/src/features/app/lib/__tests__/arena-combat-snapshot.test.ts
+++ b/src/features/app/lib/__tests__/arena-combat-snapshot.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  arenaCombatSnapshotStorageKey,
+  parseArenaCombatSnapshot,
+  snapshotMatchesCompletedRounds,
+} from '../arena-combat-snapshot';
+
+describe('arena-combat-snapshot', () => {
+  it('scopes storage keys by matchId', () => {
+    const id = '507f1f77bcf86cd799439011';
+    expect(arenaCombatSnapshotStorageKey(id)).toBe(
+      `tku-arena-combat-snapshot:${id}`
+    );
+  });
+  it('rejects invalid JSON', () => {
+    expect(parseArenaCombatSnapshot('not json')).toBeNull();
+  });
+
+  it('accepts a valid v2 snapshot with timer', () => {
+    const raw = JSON.stringify({
+      schemaVersion: 2,
+      matchId: '507f1f77bcf86cd799439011',
+      completedRounds: 0,
+      red: { health: 100, mana: 5, fouls: 0 },
+      blue: { health: 100, mana: 5, fouls: 0 },
+      timer: {
+        timeLeftMs: 45000,
+        breakTimeLeftMs: 30000,
+        isBreakTime: false,
+        roundStarted: true,
+        roundEnded: false,
+        isRunning: true,
+      },
+    });
+    const snap = parseArenaCombatSnapshot(raw);
+    expect(snap?.schemaVersion).toBe(2);
+    if (snap && snap.schemaVersion === 2) {
+      expect(snap.timer.timeLeftMs).toBe(45000);
+    }
+  });
+
+  it('accepts a valid v1 snapshot', () => {
+    const raw = JSON.stringify({
+      schemaVersion: 1,
+      matchId: '507f1f77bcf86cd799439011',
+      completedRounds: 1,
+      red: { health: 100, mana: 4, fouls: 0 },
+      blue: { health: 90, mana: 5, fouls: 1 },
+    });
+    const snap = parseArenaCombatSnapshot(raw);
+    expect(snap).not.toBeNull();
+    expect(snap!.matchId).toBe('507f1f77bcf86cd799439011');
+  });
+
+  it('rejects non-ObjectId match ids', () => {
+    const raw = JSON.stringify({
+      schemaVersion: 1,
+      matchId: 'not-an-id',
+      completedRounds: 0,
+      red: { health: 1, mana: 1, fouls: 0 },
+      blue: { health: 1, mana: 1, fouls: 0 },
+    });
+    expect(parseArenaCombatSnapshot(raw)).toBeNull();
+  });
+
+  it('snapshotMatchesCompletedRounds guards staleness', () => {
+    const snap = {
+      schemaVersion: 1 as const,
+      matchId: '507f1f77bcf86cd799439011',
+      completedRounds: 1,
+      red: { health: 10, mana: 5, fouls: 0 },
+      blue: { health: 10, mana: 5, fouls: 0 },
+    };
+    expect(snapshotMatchesCompletedRounds(snap, 1, 0)).toBe(true);
+    expect(snapshotMatchesCompletedRounds(snap, 0, 0)).toBe(false);
+    expect(snapshotMatchesCompletedRounds(snap, 2, 0)).toBe(false);
+  });
+});

--- a/src/features/app/lib/__tests__/arena-scoreboard-hydration-guard.test.ts
+++ b/src/features/app/lib/__tests__/arena-scoreboard-hydration-guard.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { isServerMatchRowForSelectedBout } from '../arena-scoreboard-hydration-guard';
+
+describe('isServerMatchRowForSelectedBout', () => {
+  it('rejects when row id differs from selected bout', () => {
+    expect(
+      isServerMatchRowForSelectedBout('507f1f77bcf86cd799439011', {
+        id: '507f191e810c19729de860ea',
+      })
+    ).toBe(false);
+  });
+
+  it('accepts when ids match', () => {
+    const id = '507f1f77bcf86cd799439011';
+    expect(isServerMatchRowForSelectedBout(id, { id })).toBe(true);
+  });
+
+  it('rejects null/undefined row', () => {
+    expect(
+      isServerMatchRowForSelectedBout('507f1f77bcf86cd799439011', null)
+    ).toBe(false);
+  });
+});

--- a/src/features/app/lib/arena-combat-snapshot.ts
+++ b/src/features/app/lib/arena-combat-snapshot.ts
@@ -1,0 +1,225 @@
+import { completedRoundsFromWins } from '@/lib/tournament/bo3';
+import { useTimerStore } from '@/stores/timer-store';
+
+/** Legacy single-key storage (pre per-matchId keys); read for migration only. */
+export const LEGACY_ARENA_COMBAT_SNAPSHOT_STORAGE_KEY =
+  'tku-arena-combat-snapshot';
+
+/** Current on-disk schema (includes round / break timer fields). */
+export const ARENA_COMBAT_SNAPSHOT_SCHEMA_VERSION = 2 as const;
+
+export type ArenaCombatSideSnapshot = {
+  health: number;
+  mana: number;
+  fouls: number;
+};
+
+export type ArenaTimerSnapshot = {
+  timeLeftMs: number;
+  breakTimeLeftMs: number;
+  isBreakTime: boolean;
+  roundStarted: boolean;
+  roundEnded: boolean;
+  isRunning: boolean;
+};
+
+export type ArenaCombatSnapshotV1 = {
+  schemaVersion: 1;
+  matchId: string;
+  completedRounds: number;
+  red: ArenaCombatSideSnapshot;
+  blue: ArenaCombatSideSnapshot;
+};
+
+export type ArenaCombatSnapshotV2 = {
+  schemaVersion: typeof ARENA_COMBAT_SNAPSHOT_SCHEMA_VERSION;
+  matchId: string;
+  completedRounds: number;
+  red: ArenaCombatSideSnapshot;
+  blue: ArenaCombatSideSnapshot;
+  timer: ArenaTimerSnapshot;
+};
+
+export type ArenaCombatPersistedSnapshot =
+  | ArenaCombatSnapshotV1
+  | ArenaCombatSnapshotV2;
+
+const isSide = (v: unknown): v is ArenaCombatSideSnapshot =>
+  typeof v === 'object' &&
+  v !== null &&
+  typeof (v as ArenaCombatSideSnapshot).health === 'number' &&
+  typeof (v as ArenaCombatSideSnapshot).mana === 'number' &&
+  typeof (v as ArenaCombatSideSnapshot).fouls === 'number';
+
+const isTimer = (v: unknown): v is ArenaTimerSnapshot =>
+  typeof v === 'object' &&
+  v !== null &&
+  typeof (v as ArenaTimerSnapshot).timeLeftMs === 'number' &&
+  typeof (v as ArenaTimerSnapshot).breakTimeLeftMs === 'number' &&
+  typeof (v as ArenaTimerSnapshot).isBreakTime === 'boolean' &&
+  typeof (v as ArenaTimerSnapshot).roundStarted === 'boolean' &&
+  typeof (v as ArenaTimerSnapshot).roundEnded === 'boolean' &&
+  typeof (v as ArenaTimerSnapshot).isRunning === 'boolean';
+
+export function isLikelyMongoObjectId(id: string): boolean {
+  return /^[a-f\d]{24}$/i.test(id);
+}
+
+/** localStorage key scoped to a match (ObjectId-safe suffix). */
+export function arenaCombatSnapshotStorageKey(matchId: string): string {
+  return `${LEGACY_ARENA_COMBAT_SNAPSHOT_STORAGE_KEY}:${matchId}`;
+}
+
+function parseSidesAndMeta(
+  o: Record<string, unknown>
+): Omit<ArenaCombatSnapshotV1, 'schemaVersion'> | null {
+  if (typeof o.matchId !== 'string' || !isLikelyMongoObjectId(o.matchId)) {
+    return null;
+  }
+  if (typeof o.completedRounds !== 'number' || o.completedRounds < 0) {
+    return null;
+  }
+  if (!isSide(o.red) || !isSide(o.blue)) return null;
+  return {
+    matchId: o.matchId,
+    completedRounds: o.completedRounds,
+    red: o.red,
+    blue: o.blue,
+  };
+}
+
+function parseV1Body(o: Record<string, unknown>): ArenaCombatSnapshotV1 | null {
+  const m = parseSidesAndMeta(o);
+  if (!m) return null;
+  return { schemaVersion: 1, ...m };
+}
+
+function parseV2Body(o: Record<string, unknown>): ArenaCombatSnapshotV2 | null {
+  const m = parseSidesAndMeta(o);
+  if (!m || !isTimer(o.timer)) return null;
+  return {
+    schemaVersion: ARENA_COMBAT_SNAPSHOT_SCHEMA_VERSION,
+    ...m,
+    timer: o.timer,
+  };
+}
+
+export function parseArenaCombatSnapshot(
+  raw: string | null
+): ArenaCombatPersistedSnapshot | null {
+  if (raw == null || raw === '') return null;
+  try {
+    const v = JSON.parse(raw) as unknown;
+    if (typeof v !== 'object' || v === null) return null;
+    const o = v as Record<string, unknown>;
+    const ver = o.schemaVersion;
+    if (ver === ARENA_COMBAT_SNAPSHOT_SCHEMA_VERSION) {
+      return parseV2Body(o);
+    }
+    if (ver === 1) {
+      return parseV1Body(o);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function snapshotMatchesCompletedRounds(
+  snap: ArenaCombatPersistedSnapshot,
+  serverRedWins: number,
+  serverBlueWins: number
+): boolean {
+  return (
+    snap.completedRounds ===
+    completedRoundsFromWins(serverRedWins, serverBlueWins)
+  );
+}
+
+export function readArenaCombatSnapshotForMatch(
+  matchId: string
+): ArenaCombatPersistedSnapshot | null {
+  if (typeof window === 'undefined' || !isLikelyMongoObjectId(matchId)) {
+    return null;
+  }
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(arenaCombatSnapshotStorageKey(matchId));
+  } catch {
+    raw = null;
+  }
+  const scoped = parseArenaCombatSnapshot(raw);
+  if (scoped) return scoped;
+
+  try {
+    raw = window.localStorage.getItem(LEGACY_ARENA_COMBAT_SNAPSHOT_STORAGE_KEY);
+  } catch {
+    raw = null;
+  }
+  const legacy = parseArenaCombatSnapshot(raw);
+  if (!legacy || legacy.matchId !== matchId) return null;
+
+  try {
+    window.localStorage.setItem(
+      arenaCombatSnapshotStorageKey(matchId),
+      JSON.stringify(legacy)
+    );
+    window.localStorage.removeItem(LEGACY_ARENA_COMBAT_SNAPSHOT_STORAGE_KEY);
+  } catch {
+    // ignore migration failures
+  }
+  return legacy;
+}
+
+export function clearArenaCombatSnapshotForMatch(matchId: string): void {
+  if (typeof window === 'undefined' || !isLikelyMongoObjectId(matchId)) return;
+  try {
+    window.localStorage.removeItem(arenaCombatSnapshotStorageKey(matchId));
+  } catch {
+    // ignore
+  }
+}
+
+export function saveArenaCombatSnapshot(
+  matchId: string,
+  snapshot: ArenaCombatSnapshotV2
+): void {
+  if (typeof window === 'undefined') return;
+  if (!isLikelyMongoObjectId(matchId) || snapshot.matchId !== matchId) return;
+  if (snapshot.schemaVersion !== ARENA_COMBAT_SNAPSHOT_SCHEMA_VERSION) return;
+  try {
+    window.localStorage.setItem(
+      arenaCombatSnapshotStorageKey(matchId),
+      JSON.stringify(snapshot)
+    );
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Restores round/break clocks from a v2 snapshot. Always clears `isRunning`
+ * so a reload does not auto-start the clock.
+ */
+export function applyPersistedArenaTimerState(
+  timer: ArenaTimerSnapshot,
+  settingsRoundDurationMs: number
+): void {
+  const ts = useTimerStore.getState();
+  const roundCap = Math.max(
+    0,
+    Math.min(Math.max(1, settingsRoundDurationMs), ts.roundDuration)
+  );
+  const timeLeft = Math.max(0, Math.min(timer.timeLeftMs, roundCap));
+  const breakCap = Math.max(0, ts.breakDuration);
+  const breakTimeLeft = Math.max(0, Math.min(timer.breakTimeLeftMs, breakCap));
+
+  useTimerStore.setState({
+    timeLeft,
+    breakTimeLeft,
+    isBreakTime: timer.isBreakTime,
+    roundStarted: timer.roundStarted,
+    roundEnded: timer.roundEnded,
+    isRunning: false,
+  });
+}

--- a/src/features/app/lib/arena-scoreboard-hydration-guard.ts
+++ b/src/features/app/lib/arena-scoreboard-hydration-guard.ts
@@ -1,0 +1,10 @@
+/**
+ * Ensures match.get payload cannot hydrate a different bout than Advance Settings.
+ * (TanStack Query already keys by id; this guards cache/coordination edge cases.)
+ */
+export function isServerMatchRowForSelectedBout(
+  selectedMatchId: string,
+  row: { id: string } | null | undefined
+): row is { id: string } {
+  return row != null && row.id === selectedMatchId;
+}

--- a/src/features/dashboard/types/group.ts
+++ b/src/features/dashboard/types/group.ts
@@ -40,7 +40,6 @@ export interface MatchData {
   round: number;
   matchIndex: number;
   status: MatchStatus;
-  bestOf: number;
   redAthleteId: string | null;
   blueAthleteId: string | null;
   redTournamentAthleteId: string | null;

--- a/src/hooks/use-round-transition.ts
+++ b/src/hooks/use-round-transition.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
+import { BO3_WINS_NEEDED } from '@/lib/tournament/bo3';
 import { useTimerStore } from '@/stores/timer-store';
 import { useMatchStore } from '@/stores/match-store';
 
@@ -25,7 +26,7 @@ export const useRoundTransition = () => {
   const prevIsBreakTime = useRef(isBreakTime);
 
   useEffect(() => {
-    const isMatchOver = redWon >= 2 || blueWon >= 2;
+    const isMatchOver = redWon >= BO3_WINS_NEEDED || blueWon >= BO3_WINS_NEEDED;
 
     if (
       prevIsBreakTime.current &&

--- a/src/lib/tournament/__test__/arena-match-label.test.ts
+++ b/src/lib/tournament/__test__/arena-match-label.test.ts
@@ -24,7 +24,6 @@ function m(
     round,
     matchIndex,
     status: 'pending',
-    bestOf: 3,
     redAthleteId: null,
     blueAthleteId: null,
     redTournamentAthleteId: null,

--- a/src/lib/tournament/__test__/bo3.test.ts
+++ b/src/lib/tournament/__test__/bo3.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BO3_MAX_ROUNDS,
+  BO3_WINS_NEEDED,
+  completedRoundsFromWins,
+  deriveArenaCurrentRound,
+} from '../bo3';
+
+describe('bo3', () => {
+  it('uses fixed wins needed and max rounds', () => {
+    expect(BO3_WINS_NEEDED).toBe(2);
+    expect(BO3_MAX_ROUNDS).toBe(3);
+  });
+
+  it('deriveArenaCurrentRound is next round to play (1-based)', () => {
+    expect(deriveArenaCurrentRound(0, 0)).toBe(1);
+    expect(deriveArenaCurrentRound(1, 0)).toBe(2);
+    expect(deriveArenaCurrentRound(0, 1)).toBe(2);
+    expect(deriveArenaCurrentRound(1, 1)).toBe(3);
+    expect(deriveArenaCurrentRound(2, 0)).toBe(3);
+    expect(deriveArenaCurrentRound(0, 2)).toBe(3);
+  });
+
+  it('completedRoundsFromWins sums wins', () => {
+    expect(completedRoundsFromWins(1, 1)).toBe(2);
+  });
+});

--- a/src/lib/tournament/__test__/bracket-action-queue.test.ts
+++ b/src/lib/tournament/__test__/bracket-action-queue.test.ts
@@ -11,7 +11,6 @@ function baseMatch(over: Partial<MatchData>): MatchData {
     round: over.round ?? 0,
     matchIndex: over.matchIndex ?? 0,
     status: over.status ?? 'pending',
-    bestOf: over.bestOf ?? 3,
     redAthleteId: over.redAthleteId ?? null,
     blueAthleteId: over.blueAthleteId ?? null,
     redTournamentAthleteId: over.redTournamentAthleteId ?? null,

--- a/src/lib/tournament/__test__/match-transition.test.ts
+++ b/src/lib/tournament/__test__/match-transition.test.ts
@@ -8,7 +8,6 @@ import {
 
 const baseMatch = {
   status: 'pending',
-  bestOf: 3,
   redWins: 0,
   blueWins: 0,
   redAthleteId: 'ap-red',

--- a/src/lib/tournament/bo3.ts
+++ b/src/lib/tournament/bo3.ts
@@ -1,0 +1,17 @@
+export const BO3_MAX_ROUNDS = 3;
+export const BO3_WINS_NEEDED = 2;
+
+export function completedRoundsFromWins(
+  redWins: number,
+  blueWins: number
+): number {
+  return redWins + blueWins;
+}
+
+export function deriveArenaCurrentRound(
+  redWins: number,
+  blueWins: number
+): number {
+  const completed = completedRoundsFromWins(redWins, blueWins);
+  return Math.min(completed + 1, BO3_MAX_ROUNDS);
+}

--- a/src/lib/tournament/bracket-shape.ts
+++ b/src/lib/tournament/bracket-shape.ts
@@ -19,7 +19,6 @@ function createEmptyMatch(
     round,
     matchIndex,
     status: 'pending',
-    bestOf: 3,
     redTournamentAthleteId: null,
     blueTournamentAthleteId: null,
     redAthleteId: null,

--- a/src/lib/tournament/match-transition.ts
+++ b/src/lib/tournament/match-transition.ts
@@ -1,5 +1,6 @@
 import type { MatchStatusDTO } from '@/orpc/matches/dto';
 import { MatchStatusSchema } from '@/orpc/matches/dto';
+import { BO3_WINS_NEEDED } from '@/lib/tournament/bo3';
 
 export type MatchTransitionData = {
   redWins?: number;
@@ -11,7 +12,6 @@ export type MatchTransitionData = {
 
 export type ScoreTransitionMatch = {
   status: string;
-  bestOf: number;
   redWins: number;
   blueWins: number;
   redAthleteId: string | null;
@@ -55,7 +55,7 @@ export function getScoreTransition(input: {
   clearAdvancement: boolean;
   advanceWinnerTournamentAthleteId: string | null;
 } {
-  const winsNeeded = Math.ceil(input.match.bestOf / 2);
+  const winsNeeded = BO3_WINS_NEEDED;
   const hadCompleted =
     input.match.status === 'complete' ||
     input.match.redWins >= winsNeeded ||

--- a/src/orpc/advance-settings/dal.ts
+++ b/src/orpc/advance-settings/dal.ts
@@ -45,7 +45,6 @@ function prismaMatchToMatchData(m: {
   round: number;
   matchIndex: number;
   status: string;
-  bestOf: number;
   redAthleteId: string | null;
   blueAthleteId: string | null;
   redTournamentAthleteId: string | null;
@@ -67,7 +66,6 @@ function prismaMatchToMatchData(m: {
     round: m.round,
     matchIndex: m.matchIndex,
     status: m.status as MatchStatus,
-    bestOf: m.bestOf,
     redAthleteId: m.redAthleteId,
     blueAthleteId: m.blueAthleteId,
     redTournamentAthleteId: m.redTournamentAthleteId,

--- a/src/orpc/matches/custom-match-label.ts
+++ b/src/orpc/matches/custom-match-label.ts
@@ -15,7 +15,6 @@ function prismaRowToMatchData(m: {
   round: number;
   matchIndex: number;
   status: string;
-  bestOf: number;
   redAthleteId: string | null;
   blueAthleteId: string | null;
   redTournamentAthleteId: string | null;
@@ -37,7 +36,6 @@ function prismaRowToMatchData(m: {
     round: m.round,
     matchIndex: m.matchIndex,
     status: m.status as MatchData['status'],
-    bestOf: m.bestOf,
     redAthleteId: m.redAthleteId,
     blueAthleteId: m.blueAthleteId,
     redTournamentAthleteId: m.redTournamentAthleteId,

--- a/src/orpc/matches/dal.ts
+++ b/src/orpc/matches/dal.ts
@@ -676,7 +676,6 @@ export class MatchDAL {
         round: MATCH_CUSTOM_ROUND,
         matchIndex: nextMatchIndex,
         status: 'pending',
-        bestOf: input.bestOf ?? 3,
         redTournamentAthleteId: red.tournamentAthleteId,
         blueTournamentAthleteId: blue.tournamentAthleteId,
         redAthleteId: red.athleteProfileId,

--- a/src/orpc/matches/dto.ts
+++ b/src/orpc/matches/dto.ts
@@ -11,7 +11,6 @@ export const MatchSchema = z.object({
   round: z.number().int(),
   matchIndex: z.number().int(),
   status: MatchStatusSchema,
-  bestOf: z.number().int(),
   redAthleteId: z.string().nullable(),
   blueAthleteId: z.string().nullable(),
   redTournamentAthleteId: z.string().nullable(),
@@ -34,7 +33,6 @@ export const CreateMatchSchema = z.object({
   round: z.number().int().default(0),
   matchIndex: z.number().int().default(0),
   status: MatchStatusSchema.default('pending'),
-  bestOf: z.number().int().default(3),
   redAthleteId: z.string().nullable().optional(),
   blueAthleteId: z.string().nullable().optional(),
   redTournamentAthleteId: z.string().nullable().optional(),
@@ -134,7 +132,6 @@ export const CreateCustomMatchSchema = z.object({
   displayLabel: z.string().min(1).max(120),
   red: CustomSlotSchema,
   blue: CustomSlotSchema,
-  bestOf: z.number().int().min(1).max(5).optional(),
 });
 
 export type MatchStatusDTO = z.infer<typeof MatchStatusSchema>;

--- a/src/queries/matches.ts
+++ b/src/queries/matches.ts
@@ -38,6 +38,26 @@ export function useTournamentMatches(tournamentId: string) {
   });
 }
 
+export function useMatchGet(
+  matchId: string | null,
+  options?: { enabled?: boolean }
+) {
+  const enabledOpt = options?.enabled ?? true;
+  const idOk = Boolean(matchId && /^[a-f\d]{24}$/i.test(matchId));
+  return useQuery({
+    queryKey: ['match', 'get', matchId] as const,
+    queryFn: ({ queryKey }) => {
+      const id = queryKey[2];
+      if (typeof id !== 'string' || !/^[\da-f]{24}$/i.test(id)) {
+        throw new Error('match.get: invalid id in queryKey');
+      }
+      return client.match.get({ id });
+    },
+    enabled: enabledOpt && idOk,
+    staleTime: 20_000,
+  });
+}
+
 function useInvalidateMatches() {
   const queryClient = useQueryClient();
   return () => {

--- a/src/stores/match-store.ts
+++ b/src/stores/match-store.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand';
 import type { PlayerData } from './player-store';
+import {
+  BO3_MAX_ROUNDS,
+  BO3_WINS_NEEDED,
+  deriveArenaCurrentRound,
+} from '@/lib/tournament/bo3';
 
 interface MatchState {
   matchId: string;
@@ -11,6 +16,8 @@ interface MatchState {
   blueWon: number;
   matchWinner: Player | null;
   isMatchOver: boolean;
+  /** Incremented when server-driven score hydration runs (arena reload sync). */
+  hydrationGeneration: number;
 }
 
 interface MatchActions {
@@ -23,6 +30,10 @@ interface MatchActions {
   setMatchOver: (winner: Player) => void;
   closeMatchResult: () => void;
   setMaxRounds: (rounds: number) => void;
+  hydrateFromServerScores: (input: {
+    redWins: number;
+    blueWins: number;
+  }) => void;
 }
 
 type MatchStore = MatchState & MatchActions;
@@ -31,12 +42,13 @@ export const useMatchStore = create<MatchStore>()((set, get) => ({
   matchId: 'Match 001',
   matchLabel: 'MATCH 001',
   currentRound: 1,
-  maxRounds: 3,
+  maxRounds: BO3_MAX_ROUNDS,
   roundWinners: [],
   redWon: 0,
   blueWon: 0,
   matchWinner: null,
   isMatchOver: false,
+  hydrationGeneration: 0,
 
   setMatchDisplay: ({ id, label }) => {
     set({ matchId: id, matchLabel: label });
@@ -99,6 +111,7 @@ export const useMatchStore = create<MatchStore>()((set, get) => ({
   resetMatch: () => {
     set({
       currentRound: 1,
+      maxRounds: BO3_MAX_ROUNDS,
       roundWinners: [],
       redWon: 0,
       blueWon: 0,
@@ -127,5 +140,25 @@ export const useMatchStore = create<MatchStore>()((set, get) => ({
 
   setMaxRounds: (rounds) => {
     set({ maxRounds: rounds });
+  },
+
+  hydrateFromServerScores: ({ redWins, blueWins }) => {
+    const isOver = redWins >= BO3_WINS_NEEDED || blueWins >= BO3_WINS_NEEDED;
+    const matchWinner: Player | null = isOver
+      ? redWins >= BO3_WINS_NEEDED
+        ? 'red'
+        : 'blue'
+      : null;
+    const placeholders: Array<Player | null> = [null, null, null];
+    set((state) => ({
+      maxRounds: BO3_MAX_ROUNDS,
+      redWon: redWins,
+      blueWon: blueWins,
+      currentRound: deriveArenaCurrentRound(redWins, blueWins),
+      roundWinners: placeholders,
+      isMatchOver: isOver,
+      matchWinner,
+      hydrationGeneration: state.hydrationGeneration + 1,
+    }));
   },
 }));

--- a/src/stores/player-store.ts
+++ b/src/stores/player-store.ts
@@ -211,6 +211,7 @@ const initializer: StateCreator<PlayerStore> = (set, get) => ({
       },
       lastRedHit: null,
       lastBlueHit: null,
+      lastHitTimes: { red: 0, blue: 0 },
     });
   },
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added arena combat snapshot persistence to automatically save and restore player health, mana, fouls, and round statistics during advance operations.
  * Added server-driven scoreboard hydration to sync match data from the server.

* **Changes**
  * Match format is now fixed to Best-of-Three (BO3) structure and no longer user-configurable.
  * Updated keyboard shortcut behavior for round and match reset operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chef0111/tku-sparring/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->