### PR TITLE
Staging

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,12 +40,12 @@ A per-tournament participation record that links an AthleteProfile to a tourname
 _Avoid_: Competitor
 
 **Arena match claim**:
-A short-lived server-side reservation tying one **Match** to one **deviceId** (and user) so Advance Settings cannot finalize the same bout on two devices at once. Enforced in `ArenaMatchClaim` with TTL and heartbeats; distinct from any group-wide lock.
-_Avoid_: Group lease, checkout, “group control”
+A server-side reservation tying one **Match** to one **deviceId** (and user) so Advance Settings cannot finalize the same bout on two devices at once. Created on Apply via `arenaMatchClaim.claim`; held until the device Applies another match in the same **Group** (prior claim released), calls `arenaMatchClaim.release`, or the row expires (30-minute TTL).
+_Avoid_: Group lease, checkout, “group control”, heartbeat
 
-**Tournament realtime (WebSocket)**:
+**Tournament realtime**:
 A per-tournament **Socket.io** room (`tournament:{id}`) on the external **realtime service**; clients refetch Advance selection and related match data after `invalidate` events. The main app notifies that service over **HTTPS** (`POST /internal/broadcast`); payloads are coarse invalidation hints, not authoritative state. See `docs/tournament-realtime.md`.
-_Avoid_: Lease stream, SSE (removed)
+_Avoid_: Lease stream, SSE
 
 **Match Label**:
 A human-readable match identifier that encodes arena and sequence (e.g., Match 101).

--- a/PRD.md
+++ b/PRD.md
@@ -49,7 +49,7 @@ In scope:
 - Custom SVG bracket canvas with DnD-kit interactions.
 - Match records created in Draft; bracket locked in Active.
 - Audit log for critical actions.
-- **Arena match claim** (per selectable match, TTL + heartbeat) so only one device can apply a match at a time; live updates via SSE.
+- **Arena match claim** (per selectable match, 30-minute TTL) so only one device can apply a match at a time; live updates via tournament realtime (Socket.io).
 - Arena client for match execution and scoring.
 - Arena-side selection flow (Advance Settings) with per-device restore.
 - Round-end score submission and match-end finalization.
@@ -234,7 +234,6 @@ Data / Inputs:
 UAC:
 
 - Each listed event captures who did it, when, and the affected entity (group/match/athlete).
-- Match-claim renewals are not logged as activity rows.
 - Activity list is filterable by event type (optional for MVP).
 
 ### 8) Arena Client (Match Execution)
@@ -255,7 +254,7 @@ UAC:
 - Arena devices restore the last selected tournament, group, and match per device.
 - Round-end results are submitted automatically.
 - "Finish Match" finalizes the match, then the operator opens the menu, chooses "Advance Settings", selects a match via combobox, and confirms.
-- Match execution keeps the active **Arena match claim** refreshed while a bout is mounted; expiry or conflicts surface when selecting/applying another match.
+- The active **Arena match claim** persists for the bout until the device Applies another match in the same group, releases it, or the TTL expires; conflicts surface when another device tries to Apply the same match.
 - If the device goes offline, scoring continues locally and syncs on reconnect.
 
 ## Functional Requirements
@@ -267,11 +266,11 @@ UAC:
 - Bracket generation is Draft-only and creates Match records; regeneration deletes and recreates Draft matches.
 - Active tournaments allow score edits but no shuffle; bracket changes require explicit unlock.
 - Completed tournaments are read-only.
-- Applying Advance Settings succeeds only after `**arenaMatchClaim.claim`\*\* for the chosen match; another device holding a non-expired claim blocks Apply for that row.
-- **Arena match claims** use a ~60s TTL; the arena sends **heartbeats** on the configured interval while a match id is active.
-- **SSE** broadcasts `**invalidate`\*\* for a tournament so all clients refresh Advance selection queries (`selectionCatalog`, `selectionMatches`) and bracket `match` queries.
+- Applying Advance Settings succeeds only after `arenaMatchClaim.claim` for the chosen match; another device holding a non-expired claim blocks Apply for that row.
+- **Arena match claims** use a 30-minute TTL. A new Apply in the same group releases the device’s prior claim; `arenaMatchClaim.release` is also available. Expired rows are cleaned up on subsequent claim operations.
+- **Tournament realtime** (Socket.io) delivers `invalidate` for a tournament so all clients refresh Advance selection queries (`selectionCatalog`, `selectionMatches`) and bracket `match` queries. See `docs/tournament-realtime.md`.
 - Coordinating identity uses a persistent **device UUID** in `localStorage`.
-- **Finish Match** releases the claim and clears the advance form match field; explicit release on unload is best-effort; TTL remains the safety net.
+- After **Finish Match**, the operator returns to Advance Settings to pick the next match; the prior claim remains until replaced or TTL expiry.
 - Performance targets: 256 athletes per tournament, 8 groups per tournament, 32 athletes per group.
 - Arena client is a separate experience from the admin CRM.
 - Arena selection uses Advance Settings as the primary flow for MVP.
@@ -296,7 +295,7 @@ UAC:
   - Bracket generation + audit log
 - Phase 2: Arena Client Integration
   - Advance Settings API integration
-  - Match claims + tournament SSE for selection sync
+  - Match claims + tournament realtime (Socket.io) for selection sync
   - Round-end submission + Finish Match flow
 - Phase 3: Hardening + Scale
   - Offline tolerance improvements

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TKU Sparring System • ![License](https://img.shields.io/badge/License-MIT-blue)
 
-A modern, user-friendly web application for managing Taekwondo sparring matches of UIT Taekwondo Tournaments.
+A tournament operations platform for UIT Taekwondo: an admin CRM for athletes, groups, and brackets, plus an arena client for live match scoring.
 
 ## 🚀 Installation Guide
 
@@ -14,26 +14,77 @@ Refer to [DEVELOPMENT.md](./DEVELOPMENT.md) for detailed instructions on how to 
 
 ## 🔋 Features
 
+### Admin CRM
+
 <table>
   <tr>
     <th>Feature</th>
     <th>Description</th>
   </tr>
   <tr>
-    <td>Match Configuration</td>
-    <td>Customizable player names, round duration (10-300s), break time, health points, up to 3 rounds</td>
+    <td>Operations hub</td>
+    <td>Cross-tournament KPIs, status pipeline, and recent tournaments at <code>/dashboard</code></td>
   </tr>
   <tr>
-    <td>Scoring System</td>
-    <td>6-point scoring (6/4/3/2/1 points), automatic health updates, visual feedback on critical hits</td>
+    <td>Command center</td>
+    <td>Per-tournament monitoring, setup checklist, and lifecycle actions; editing stays in the builder</td>
   </tr>
   <tr>
-    <td>Penalty & Mana System</td>
-    <td>Gam-jeom tracking, 5-point mana system, penalties reduce mana and can end match</td>
+    <td>Global athlete registry</td>
+    <td>CRUD for <strong>AthleteProfile</strong> records, de-dup validation, filters, and bulk add to tournaments</td>
   </tr>
   <tr>
-    <td>Timer & Scoring</td>
-    <td>Round timer with countdown, break time between rounds, scoring enabled only during active rounds</td>
+    <td>Tournament builder — Groups</td>
+    <td>Constraint-based auto-assign, manual drag-and-drop, out-of-range warnings, per-group third-place toggle, arena assignment</td>
+  </tr>
+  <tr>
+    <td>Tournament builder — Brackets</td>
+    <td>Single-elimination bracket canvas, shuffle, seed locks, custom matches, corner swap, match detail panel</td>
+  </tr>
+  <tr>
+    <td>Bracket export & fullscreen</td>
+    <td>Fit-to-content PNG screenshot and immersive fullscreen view of the bracket canvas</td>
+  </tr>
+  <tr>
+    <td>Match results & lifecycle</td>
+    <td>Best-of-three round wins, Draft → Active → Completed transitions, manual winner overrides with audit trail</td>
+  </tr>
+  <tr>
+    <td>Audit log</td>
+    <td>Per-tournament activity for score edits, reseeds, group changes, and manual overrides</td>
+  </tr>
+</table>
+
+### Arena client
+
+<table>
+  <tr>
+    <th>Feature</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>Advance Settings</td>
+    <td>Select tournament, group, and match before a bout; per-device restore of last selection</td>
+  </tr>
+  <tr>
+    <td>Arena match claim</td>
+    <td>One device per match at a time (30-minute claim TTL); other devices see matches as in use</td>
+  </tr>
+  <tr>
+    <td>Tournament realtime</td>
+    <td>Socket.io invalidation keeps Advance Settings and bracket views in sync across devices</td>
+  </tr>
+  <tr>
+    <td>Live scoring</td>
+    <td>Full-screen scoreboard with round timer, technique scoring, health and mana, and gam-jeom penalties</td>
+  </tr>
+  <tr>
+    <td>Round & match flow</td>
+    <td>Automatic round-end submission, Finish Match to finalize, then return to Advance Settings (no auto-advance)</td>
+  </tr>
+  <tr>
+    <td>Offline tolerance</td>
+    <td>Scoring continues locally when connectivity drops; syncs on reconnect</td>
   </tr>
 </table>
 

--- a/docs/tournament-realtime.md
+++ b/docs/tournament-realtime.md
@@ -1,6 +1,6 @@
 # Tournament realtime (Socket.io)
 
-A small **Node realtime service** in [`realtime/`](../realtime/) runs Socket.io. After mutations, server code calls `publishSelectionInvalidate` in [`src/lib/tournament/tournament-sse-bus.ts`](../src/lib/tournament/tournament-sse-bus.ts), which `POST`s to the realtime service’s `/internal/broadcast` endpoint so all browsers in room `tournament:{id}` receive an `invalidate` event and refetch via TanStack Query ([`advance-selection-invalidation.ts`](../src/queries/advance-selection-invalidation.ts)).
+A small **Node realtime service** in [`realtime/`](../realtime/) runs Socket.io. After mutations, server code calls `publishSelectionInvalidate` in [`src/lib/tournament/tournament-realtime-broadcast.ts`](../src/lib/tournament/tournament-realtime-broadcast.ts), which `POST`s to the realtime service’s `/internal/broadcast` endpoint so all browsers in room `tournament:{id}` receive an `invalidate` event and refetch via TanStack Query ([`advance-selection-invalidation.ts`](../src/queries/advance-selection-invalidation.ts)).
 
 ## Environment (main app)
 

--- a/src/lib/tournament/__test__/tournament-realtime-broadcast.test.ts
+++ b/src/lib/tournament/__test__/tournament-realtime-broadcast.test.ts
@@ -1,11 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  publishMatchInvalidateEvent,
-  publishSelectionInvalidate,
-} from '../tournament-sse-bus';
+import { publishSelectionInvalidate } from '../tournament-realtime-broadcast';
 
-describe('tournament realtime bus', () => {
+describe('tournament realtime broadcast', () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
@@ -41,16 +38,6 @@ describe('tournament realtime bus', () => {
     expect(JSON.parse(String(init.body))).toEqual({
       tournamentId: 't-1',
       event: { type: 'invalidate', tournamentId: 't-1' },
-    });
-  });
-
-  it('aliases publishMatchInvalidateEvent to selection invalidate', async () => {
-    publishMatchInvalidateEvent('t-2');
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(JSON.parse(String(init.body))).toEqual({
-      tournamentId: 't-2',
-      event: { type: 'invalidate', tournamentId: 't-2' },
     });
   });
 });

--- a/src/lib/tournament/tournament-realtime-broadcast.ts
+++ b/src/lib/tournament/tournament-realtime-broadcast.ts
@@ -1,9 +1,9 @@
-export interface TournamentSseInvalidateEvent {
+export interface TournamentInvalidateEvent {
   type: 'invalidate';
   tournamentId: string;
 }
 
-export type TournamentSseEvent = TournamentSseInvalidateEvent;
+export type TournamentRealtimeEvent = TournamentInvalidateEvent;
 
 let loggedMissingRealtime = false;
 
@@ -15,7 +15,7 @@ function getBroadcastConfig() {
 
 async function postInternalBroadcast(
   tournamentId: string,
-  event: TournamentSseEvent
+  event: TournamentRealtimeEvent
 ) {
   const cfg = getBroadcastConfig();
   if (!cfg) {
@@ -47,10 +47,6 @@ async function postInternalBroadcast(
 
 /** Notifies all browsers in `tournament:{id}` via the external realtime service. */
 export function publishSelectionInvalidate(tournamentId: string) {
-  const event: TournamentSseEvent = { type: 'invalidate', tournamentId };
+  const event: TournamentRealtimeEvent = { type: 'invalidate', tournamentId };
   void postInternalBroadcast(tournamentId, event);
-}
-
-export function publishMatchInvalidateEvent(tournamentId: string) {
-  publishSelectionInvalidate(tournamentId);
 }

--- a/src/orpc/arena-match-claim/__tests__/arena-match-claim.dal.test.ts
+++ b/src/orpc/arena-match-claim/__tests__/arena-match-claim.dal.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ArenaMatchClaimDAL } from '../dal';
 import { prisma } from '@/lib/db';
-import { publishSelectionInvalidate } from '@/lib/tournament/tournament-sse-bus';
+import { publishSelectionInvalidate } from '@/lib/tournament/tournament-realtime-broadcast';
 
 const tx = {
   arenaMatchClaim: {
@@ -37,7 +37,7 @@ vi.mock('@/lib/db', () => ({
   },
 }));
 
-vi.mock('@/lib/tournament/tournament-sse-bus', () => ({
+vi.mock('@/lib/tournament/tournament-realtime-broadcast', () => ({
   publishSelectionInvalidate: vi.fn(),
 }));
 

--- a/src/orpc/arena-match-claim/dal.ts
+++ b/src/orpc/arena-match-claim/dal.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@/lib/db';
-import { publishSelectionInvalidate } from '@/lib/tournament/tournament-sse-bus';
+import { publishSelectionInvalidate } from '@/lib/tournament/tournament-realtime-broadcast';
 
 const CLAIM_TTL_MS = 30 * 60 * 1000;
 

--- a/src/orpc/groups/dal.ts
+++ b/src/orpc/groups/dal.ts
@@ -8,7 +8,7 @@ import type {
 } from './dto';
 import { recordTournamentActivity } from '@/orpc/activity/dal';
 import { prisma } from '@/lib/db';
-import { publishSelectionInvalidate } from '@/lib/tournament/tournament-sse-bus';
+import { publishSelectionInvalidate } from '@/lib/tournament/tournament-realtime-broadcast';
 
 export class GroupDAL {
   private static readonly UNASSIGNED_GROUP_FILTER = {

--- a/src/orpc/matches/__tests__/match-transition-write.test.ts
+++ b/src/orpc/matches/__tests__/match-transition-write.test.ts
@@ -4,7 +4,7 @@ import { advanceWinner, clearWinnerAdvancement } from '../match-progression';
 import { applyMatchTransition } from '../match-transition-write';
 import { prisma } from '@/lib/db';
 import { recordTournamentActivity } from '@/orpc/activity/dal';
-import { publishMatchInvalidateEvent } from '@/lib/tournament/tournament-sse-bus';
+import { publishSelectionInvalidate } from '@/lib/tournament/tournament-realtime-broadcast';
 
 const tx = {
   match: {
@@ -34,8 +34,8 @@ vi.mock('@/orpc/activity/dal', () => ({
   recordTournamentActivity: vi.fn(),
 }));
 
-vi.mock('@/lib/tournament/tournament-sse-bus', () => ({
-  publishMatchInvalidateEvent: vi.fn(),
+vi.mock('@/lib/tournament/tournament-realtime-broadcast', () => ({
+  publishSelectionInvalidate: vi.fn(),
 }));
 
 beforeEach(() => {
@@ -90,7 +90,7 @@ describe('applyMatchTransition', () => {
       }),
       tx
     );
-    expect(publishMatchInvalidateEvent).toHaveBeenCalledWith('t-1');
-    expect(publishMatchInvalidateEvent).toHaveBeenCalledTimes(1);
+    expect(publishSelectionInvalidate).toHaveBeenCalledWith('t-1');
+    expect(publishSelectionInvalidate).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/orpc/matches/__tests__/matches.dal.test.ts
+++ b/src/orpc/matches/__tests__/matches.dal.test.ts
@@ -38,8 +38,8 @@ vi.mock('@/orpc/activity/dal', () => ({
   recordTournamentActivity: vi.fn(),
 }));
 
-vi.mock('@/lib/tournament/tournament-sse-bus', () => ({
-  publishMatchInvalidateEvent: vi.fn(),
+vi.mock('@/lib/tournament/tournament-realtime-broadcast', () => ({
+  publishSelectionInvalidate: vi.fn(),
 }));
 
 vi.mock('@/orpc/matches/custom-match-label', () => ({
@@ -888,8 +888,8 @@ describe('adminSetMatchStatus', () => {
 
 describe('createCustom', () => {
   it('creates custom match with direct athletes and notifies realtime', async () => {
-    const { publishMatchInvalidateEvent } =
-      await import('@/lib/tournament/tournament-sse-bus');
+    const { publishSelectionInvalidate } =
+      await import('@/lib/tournament/tournament-realtime-broadcast');
     vi.mocked(prisma.group.findUnique).mockResolvedValue({
       id: 'group-1',
       tournamentId: 't-1',
@@ -942,6 +942,6 @@ describe('createCustom', () => {
         }),
       })
     );
-    expect(publishMatchInvalidateEvent).toHaveBeenCalledWith('t-1');
+    expect(publishSelectionInvalidate).toHaveBeenCalledWith('t-1');
   });
 });

--- a/src/orpc/matches/dal.ts
+++ b/src/orpc/matches/dal.ts
@@ -28,7 +28,7 @@ import {
   buildWinnerOverridePlan,
 } from '@/lib/tournament/match-transition';
 import { recordTournamentActivity } from '@/orpc/activity/dal';
-import { publishMatchInvalidateEvent } from '@/lib/tournament/tournament-sse-bus';
+import { publishSelectionInvalidate } from '@/lib/tournament/tournament-realtime-broadcast';
 import { prisma } from '@/lib/db';
 
 const MATCH_CUSTOM_ROUND = 900;
@@ -300,7 +300,7 @@ export class MatchDAL {
       payload: { groupId: input.groupId, displayLabel },
     });
 
-    publishMatchInvalidateEvent(group.tournamentId);
+    publishSelectionInvalidate(group.tournamentId);
 
     return coalesceMatchRead(row);
   }

--- a/src/orpc/matches/match-transition-write.ts
+++ b/src/orpc/matches/match-transition-write.ts
@@ -3,7 +3,7 @@ import { coalesceMatchRead } from './match-read';
 import type { MatchTransitionPlan } from '@/lib/tournament/match-transition';
 import type { ActivityInput } from '@/orpc/activity/types';
 import { recordTournamentActivity } from '@/orpc/activity/dal';
-import { publishMatchInvalidateEvent } from '@/lib/tournament/tournament-sse-bus';
+import { publishSelectionInvalidate } from '@/lib/tournament/tournament-realtime-broadcast';
 import { prisma } from '@/lib/db';
 
 export async function applyMatchTransition(input: {
@@ -47,6 +47,6 @@ export async function applyMatchTransition(input: {
     return { updated, tournamentId: match.tournamentId };
   });
 
-  publishMatchInvalidateEvent(result.tournamentId);
+  publishSelectionInvalidate(result.tournamentId);
   return coalesceMatchRead(result.updated);
 }

--- a/src/orpc/tournaments/__tests__/tournaments.dal.test.ts
+++ b/src/orpc/tournaments/__tests__/tournaments.dal.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TournamentDAL } from '../dal';
 import { prisma } from '@/lib/db';
 
-vi.mock('@/lib/tournament/tournament-sse-bus', () => ({
+vi.mock('@/lib/tournament/tournament-realtime-broadcast', () => ({
   publishSelectionInvalidate: vi.fn(),
 }));
 

--- a/src/orpc/tournaments/tournament-arena-order.ts
+++ b/src/orpc/tournaments/tournament-arena-order.ts
@@ -10,7 +10,7 @@ import {
   mergeArenaGroupOrderAfterRetireArena,
   patchArenaGroupOrderJson,
 } from '@/lib/tournament/arena-group-order';
-import { publishSelectionInvalidate } from '@/lib/tournament/tournament-sse-bus';
+import { publishSelectionInvalidate } from '@/lib/tournament/tournament-realtime-broadcast';
 import { prisma } from '@/lib/db';
 
 async function loadTournament(tournamentId: string, draftMessage: string) {

--- a/src/orpc/tournaments/tournament-lifecycle.ts
+++ b/src/orpc/tournaments/tournament-lifecycle.ts
@@ -9,7 +9,7 @@ import type {
 import type { Prisma } from '@/generated/prisma/client';
 import { prisma } from '@/lib/db';
 import { getNameSortKey } from '@/lib/sort/name-sort-key';
-import { publishSelectionInvalidate } from '@/lib/tournament/tournament-sse-bus';
+import { publishSelectionInvalidate } from '@/lib/tournament/tournament-realtime-broadcast';
 
 type TournamentLookupDatabase = Pick<typeof prisma, 'match' | 'tournament'>;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Arena match claims now enforce 30-minute TTL with device binding; new match applications in the same group automatically release prior claims.
  * Tournament realtime synchronization now delivers cache-invalidation events over Socket.io for Advance selection and bracket match queries.

* **Documentation**
  * Clarified arena match-claim lifecycle, conflict handling, and tournament realtime invalidation mechanics across specification and reference docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->